### PR TITLE
Delete .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-#This file stores API keys for the project.
-
-DELPHI_API_KEY=your_delphi_api_key 
-NOAA_CDO_TOKEN=your_noaa_token 
-COVID_API_KEY=your_covid_api_key


### PR DESCRIPTION
Deleted the .env file because "hiding" the API key is not required, per the instructor response on Piazza. https://piazza.com/class/lzh9fek3gzw3bq/post/334